### PR TITLE
make should call x86_64-pc-elf-ld for systems with a non-crosscompile…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ $(iso): $(kernel)
 kernel: $(kernel)
 
 $(kernel): cargo $(rust_os) $(assembly_object_files) $(linker_script)
-	ld -n --gc-sections -T $(linker_script) -o $(kernel) $(assembly_object_files) $(rust_os)
+	x86_64-pc-elf-ld -n --gc-sections -T $(linker_script) -o $(kernel) $(assembly_object_files) $(rust_os)
 
 cargo:
 	cargo build --target $(target)


### PR DESCRIPTION
Fixes https://github.com/intermezzOS/kernel/issues/19.

Calls an explicitly labeled cross-linker instead of using the generic system "ld".