### PR TITLE
new target: make distclean

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,9 +17,16 @@ libcore := $(libcore_dir)/libcore.rlib
 
 all: $(iso)
 
-clean:
+distclean:
 	rm -rf build
 	rm -rf target
+
+clean:
+	rm -rf build/isofiles
+	rm -rf build/arch
+	rm -rf target
+	rm -f $(kernel)
+	rm -f $(iso)
 
 run: $(iso)
 	qemu-system-x86_64 -cdrom $(iso)


### PR DESCRIPTION
Now that we're building all of libcore on a clean build, I'd like to
introduce a split between clean builds: clean vs distclean. The idea
here is that 'distclean' does a _full_ clean: it makes things the same
way that they would be if you were to download the source. 'clean' will
now not clean the dependencies, just the code for the kernel itself.

This will make it a bit easier/faster to rebuild the kernel itself,
not forcing a full re-clone of the libcore repo, which will grow over
time. In addition, if we start to build our own binutils, this will be
cleaned by distclean, but not clean.