### PR TITLE
Mark kmain() as never returning

### DIFF
--- a/src/src/lib.rs
+++ b/src/src/lib.rs
@@ -13,7 +13,7 @@ extern crate keyboard;
 pub mod support; // For Rust lang items
 
 #[no_mangle]
-pub extern "C" fn kmain() {
+pub extern "C" fn kmain() -> ! {
     vga::clear_console();
 
     unsafe { enable_interrupts() };


### PR DESCRIPTION
This may help catch the bug you mentioned in https://www.youtube.com/watch?v=iTSx-8qK4Hw where you forgot to include `loop { }`, so `kmain` immediately returned to the boot assembly which continued to `hlt ; This should never happen`.