### PR TITLE
Buffer scrolling bug fix

### DIFF
--- a/src/vga/src/lib.rs
+++ b/src/vga/src/lib.rs
@@ -52,12 +52,12 @@ pub static BUFFER: Mutex<VgaBuffer> = Mutex::new(VgaBuffer {
     buffer: [VgaCell {
         character: ' ' as u8,
         color: DEFAULT_COLOR,
-    }; (CONSOLE_ROWS * CONSOLE_COLS * 2) as usize],
+    }; (CONSOLE_ROWS * CONSOLE_COLS) as usize],
     position: 0,
 });
 
 pub struct VgaBuffer {
-    buffer: [VgaCell; (CONSOLE_ROWS * CONSOLE_COLS * 2) as usize],
+    buffer: [VgaCell; (CONSOLE_ROWS * CONSOLE_COLS) as usize],
     position: usize,
 }
 
@@ -67,7 +67,7 @@ impl VgaBuffer {
             // to get the current line, we divide by the length of a line
             let current_line = (self.position as isize) / CONSOLE_COLS;
 
-            let next_line = if current_line + 1 > CONSOLE_ROWS {
+            let next_line = if current_line + 1 >= CONSOLE_ROWS {
 
                 let end = CONSOLE_ROWS * CONSOLE_COLS;
 
@@ -118,7 +118,7 @@ impl VgaBuffer {
     }
 
     fn clear(&mut self) {
-        for i in 0..(CONSOLE_ROWS * CONSOLE_COLS * 2) {
+        for i in 0..(CONSOLE_ROWS * CONSOLE_COLS) {
             let cell = &mut self.buffer[i as usize];
             *cell = VgaCell {
                 character: ' ' as u8,


### PR DESCRIPTION
This fixes the handling of next_line when we are trying to determine if the next_line should be the last line . Before the position index would not be correct if it was equal to the size of the buffer. I've also reduced the size of the buffer because it seemed to be twice as large as needed. 
 
To see the side affect of this bug, reduce the the row count below 25 and enter enough text for scrolling logic to execute. 