### PR TITLE
Pin libcore to a certain revision

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -52,6 +52,7 @@ $(kernel): cargo $(rust_os) $(assembly_object_files) $(linker_script)
 build/libcore:
 	mkdir -p build
 	git clone https://github.com/intermezzOS/libcore build/libcore
+	cd build/libcore && git reset --hard 02e41cd5b925a1c878961042ecfb00470c68296b
 
 libcore: $(libcore)
 


### PR DESCRIPTION
Initially a concern in b294480f404b1fccbf745ea53affca9b48b9e482, this
commit now checks out a specific hash of our libcore, so that when we
update it, people's stuff won't break, until we update it here as well.
This allows us to experiment a bit more freely with upgrades, but not
make them 'official' until the SHA here is updated.

Fixes #25