### PR TITLE
Refactor VgaBuffer::write_byte a bit

### DIFF
--- a/src/vga/src/lib.rs
+++ b/src/vga/src/lib.rs
@@ -68,25 +68,22 @@ impl VgaBuffer {
         if byte == ('\n' as u8) {
             // to get the current line, we divide by the length of a line
             let current_line = (self.position as isize) / CONSOLE_COLS;
-
-            if current_line + 1 >= CONSOLE_ROWS {
-                self.scroll_up();
-            } else {
-                self.position = ((current_line + 1) * CONSOLE_COLS) as usize;
-            }
+            self.position = ((current_line + 1) * CONSOLE_COLS) as usize;
         } else {
-            if self.position >= self.buffer.len() {
-                self.scroll_up();
-            }
             let cell = &mut self.buffer[self.position];
 
             *cell = VgaCell {
                 character: byte,
                 color: color,
             };
-
+            
             self.position += 1;
         }
+
+        if self.position >= self.buffer.len() {
+            self.scroll_up();
+        }
+
         set_cursor(self.position as u16);
     }
 


### PR DESCRIPTION
Simplified the scroll up procedure. Scroll up is only called once; after the byte is written and before the cursor position is set. This changes the behavior a bit, before it would scroll up if the byte being written was to be on the next position outside the buffer, now it scrolls up if the next character written will be outside the buffer. This also fixes an issue where the cursor would be hidden if the next byte position was outside the buffer.