### PR TITLE
Remove unsafe from Vga's constructor.

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1,10 +1,6 @@
 [root]
 name = "vga"
 version = "0.1.0"
-dependencies = [
- "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "intermezzos"

--- a/src/src/kernel/mod.rs
+++ b/src/src/kernel/mod.rs
@@ -6,7 +6,7 @@ use spin::Mutex;
 mod kprint;
 
 pub struct Context {
-    pub vga: Mutex<Vga<'static>>,
+    pub vga: Mutex<Vga<&'static mut [u8]>>,
 }
 
 impl Context {
@@ -20,4 +20,3 @@ impl Context {
         }
     }
 }
-

--- a/src/src/kernel/mod.rs
+++ b/src/src/kernel/mod.rs
@@ -1,19 +1,23 @@
-use spin::Mutex;
+use core;
 use vga::Vga;
+use spin::Mutex;
 
 #[macro_use]
 mod kprint;
 
 pub struct Context {
-    pub vga: Mutex<Vga>,
+    pub vga: Mutex<Vga<'static>>,
 }
 
 impl Context {
-    pub const fn new() -> Context {
-        unsafe {
-            Context {
-                vga: Mutex::new(Vga::new(0xb8000 as *mut u8)),
-            }
+    pub fn new() -> Context {
+        let slice = unsafe {
+            core::slice::from_raw_parts_mut(0xb8000 as *mut u8, 4000)
+        };
+
+        Context {
+            vga: Mutex::new(Vga::new(slice)),
         }
     }
 }
+

--- a/src/vga/Cargo.toml
+++ b/src/vga/Cargo.toml
@@ -4,5 +4,3 @@ version = "0.1.0"
 authors = ["Steve Klabnik <steve@steveklabnik.com>"]
 
 [dependencies]
-spin = "0.4.2"
-rlibc = "1.0.0"

--- a/src/vga/src/lib.rs
+++ b/src/vga/src/lib.rs
@@ -19,7 +19,7 @@ pub struct Vga<T: AsMut<[u8]>> {
 impl<T: AsMut<[u8]>> Vga<T> {
     pub fn new(mut slice: T) -> Vga<T> {
         // we must have enough bytes of backing storage to make this work.
-        assert!(slice.as_mut().len() == ROWS * COL_BYTES);
+        assert_eq!(slice.as_mut().len(), ROWS * COL_BYTES);
 
         Vga {
             slice: slice,

--- a/src/vga/tests/vga.rs
+++ b/src/vga/tests/vga.rs
@@ -8,7 +8,7 @@ use vga::Vga;
 fn create() {
     let mut mock_memory = vec![0u8; 25 * 80 * 2];
 
-    unsafe { Vga::new(mock_memory.as_mut_ptr()) };
+    Vga::new(&mut mock_memory);
 }
 
 fn check_write<T: Write>(_: T) { }
@@ -16,7 +16,7 @@ fn check_write<T: Write>(_: T) { }
 #[test]
 fn write() {
     let mut mock_memory = vec![0u8; 25 * 80 * 2];
-    let vga = unsafe { Vga::new(mock_memory.as_mut_ptr()) };
+    let vga = Vga::new(&mut mock_memory);
     check_write(vga);
 }
 
@@ -24,11 +24,13 @@ fn write() {
 fn flush() {
     let mut mock_memory = vec![0u8; 25 * 80 * 2];
 
-    let mut vga = unsafe { Vga::new(mock_memory.as_mut_ptr()) };
+    {
+        let mut vga = Vga::new(&mut mock_memory);
 
-    vga.write_str("hello").unwrap();
+        vga.write_str("hello").unwrap();
 
-    vga.flush();
+        vga.flush();
+    }
 
     assert_eq!(mock_memory[0], 'h' as u8);
     assert_eq!(mock_memory[1], 0x02);


### PR DESCRIPTION
Turns out, we don't need to worry about this! We can accept a mutable
slice instead, and panic if it's the wrong length.

This now means that the VGA driver is 100% safe, and the only mention of
unsafety in the kernel at all is the creation of the slice to video
memory.

Since I was changing the signature of Vga::new, I also cleaned up some
of the const fn stuff that used to matter when we had a static Vga, but
now do not. :metal: