### PR TITLE
Interrupts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,10 +1,29 @@
 [root]
-name = "interrupts"
+name = "pic"
 version = "0.1.0"
+
+[[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "console"
 version = "0.1.0"
+
+[[package]]
+name = "csv"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "intermezzos"
@@ -12,9 +31,133 @@ version = "0.1.0"
 dependencies = [
  "console 0.1.0",
  "interrupts 0.1.0",
+ "pic 0.1.0",
  "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "interrupts"
+version = "0.1.0"
+dependencies = [
+ "pic 0.1.0",
+ "x86 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "phf"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rlibc"
@@ -22,10 +165,66 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-serialize"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "spin"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "x86"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raw-cpuid 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+"checksum csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)" = "266c1815d7ca63a5bd86284043faf91e8c95e943e55ce05dc0ae08e952de18bc"
+"checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
+"checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
+"checksum num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "88b14378471f7c2adc5262f05b4701ef53e8da376453a8d8fee48e51db745e49"
+"checksum num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c78e054dd19c3fd03419ade63fa661e9c49bb890ce3beb4eee5b7baf93f92f"
+"checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
+"checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
+"checksum num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "54ff603b8334a72fbb27fe66948aac0abaaa40231b3cecd189e76162f6f38aaf"
+"checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
+"checksum phf 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)" = "52c875926de24c01b5b69153eaa258b57920a39b44bbce8ef1f2052a6c5a6a1a"
+"checksum phf_codegen 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0a8912c2cc0ea2e8ae70388ec0af9a445e7ab37b3c9cc61f059c2b34db8ed50b"
+"checksum phf_generator 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)" = "04b5ea825e28cb6efd89d9133b129b2003b45a221aeda025509b125b00ecb7c4"
+"checksum phf_shared 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2c43b5dbe94d31f1f4ed45c50bb06d70e72fd53f15422b0a915b5c237e130dd6"
+"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
+"checksum raw-cpuid 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7bc8e963398e6244e1d51c42dd68394f273d39ed8afc9238b74f56041b23dbd3"
 "checksum rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
+"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97b18e9e53de541f11e497357d6c5eaeb39f0cb9c8734e274abe4935f6991fa"
+"checksum serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b5aaee47e038bf9552d30380d3973fff2593ee0a76d81ad4c581f267cdcadf36"
 "checksum spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f7035cd2694c317f8ff90efb00feb9e7268febbf6e9b28a8d16da8eb202493"
+"checksum x86 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "289a79c6ffe63e7948823bc7e6b617856325c752dfec28c4ba50f50a824f55a2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "pic 0.1.0",
  "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x86 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,15 +1,20 @@
 [root]
-name = "intermezzos"
+name = "interrupts"
 version = "0.1.0"
-dependencies = [
- "console 0.1.0",
- "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "console"
 version = "0.1.0"
+
+[[package]]
+name = "intermezzos"
+version = "0.1.0"
+dependencies = [
+ "console 0.1.0",
+ "interrupts 0.1.0",
+ "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rlibc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ name = "interrupts"
 version = "0.1.0"
 dependencies = [
  "pic 0.1.0",
+ "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "console 0.1.0",
  "interrupts 0.1.0",
  "keyboard 0.1.0",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pic 0.1.0",
  "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -49,6 +50,14 @@ dependencies = [
 [[package]]
 name = "keyboard"
 version = "0.1.0"
+
+[[package]]
+name = "lazy_static"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
@@ -214,6 +223,7 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)" = "266c1815d7ca63a5bd86284043faf91e8c95e943e55ce05dc0ae08e952de18bc"
+"checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
 "checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "88b14378471f7c2adc5262f05b4701ef53e8da376453a8d8fee48e51db745e49"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ version = "0.1.0"
 dependencies = [
  "console 0.1.0",
  "interrupts 0.1.0",
+ "keyboard 0.1.0",
  "pic 0.1.0",
  "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -44,6 +45,10 @@ dependencies = [
  "pic 0.1.0",
  "x86 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "keyboard"
+version = "0.1.0"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 rlibc = "1.0.0"
 spin = "0.4.4"
 console = { path = "console" }
+interrupts = { path = "interrupts" }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ x86 = "0.8.0"
 console = { path = "console" }
 interrupts = { path = "interrupts" }
 pic = { path = "pic" }
+keyboard = { path = "keyboard" }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 [dependencies]
 rlibc = "1.0.0"
 spin = "0.4.4"
+x86 = "0.8.0"
 console = { path = "console" }
 interrupts = { path = "interrupts" }
 pic = { path = "pic" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 [workspace]
 
 [dependencies]
+lazy_static = { version = "0.2.1", features = ["spin_no_std"] }
 rlibc = "1.0.0"
 spin = "0.4.4"
 x86 = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rlibc = "1.0.0"
 spin = "0.4.4"
 console = { path = "console" }
 interrupts = { path = "interrupts" }
+pic = { path = "pic" }
 
 [profile.dev]
 panic = "abort"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ cargo:
 test:
 	cd console && cargo test
 	cd interrupts && cargo test
+	cd keyboard && cargo test
 	cd pic && cargo test
 
 iso: cargo grub.cfg

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ cargo:
 # cargo test fails for some reason, not sure why yet
 test:
 	cd console && cargo test
+	cd interrupts && cargo test
+	cd pic && cargo test
 
 iso: cargo grub.cfg
 	mkdir -p target/isofiles/boot/grub

--- a/interrupts/Cargo.toml
+++ b/interrupts/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "interrupts"
+version = "0.1.0"
+authors = ["The intermezzOS team"]
+
+[dependencies]

--- a/interrupts/Cargo.toml
+++ b/interrupts/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 authors = ["The intermezzOS team"]
 
 [dependencies]
+spin = "0.4.4"
 x86 = "0.8.0"
 pic = { path = "../pic" }

--- a/interrupts/src/lib.rs
+++ b/interrupts/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+pub struct IdtRef;
+
+pub fn idt_ref() -> IdtRef {
+    IdtRef
+}

--- a/interrupts/src/lib.rs
+++ b/interrupts/src/lib.rs
@@ -79,6 +79,8 @@ pub struct IdtRef {
     idt: &'static mut [IdtEntry; 256],
 }
 
+unsafe impl Send for IdtRef {}
+
 impl IdtRef {
     pub fn set_handler(&mut self, index: usize, entry: IdtEntry) {
         self.idt[index] = entry;
@@ -87,7 +89,7 @@ impl IdtRef {
 
 pub fn idt_ref() -> IdtRef {
 	// accessing the static mut idt
-	let mut r = unsafe {
+	let r = unsafe {
 		IdtRef {
 			ptr: DescriptorTablePointer::new_idtp(&IDT[..]),
             idt: &mut IDT,

--- a/interrupts/src/lib.rs
+++ b/interrupts/src/lib.rs
@@ -85,26 +85,25 @@ pub struct IdtRef {
 unsafe impl Sync for IdtRef {}
 
 impl IdtRef {
+    pub fn new() -> IdtRef {
+        let r = IdtRef {
+            ptr: DescriptorTablePointer::new_idtp(&IDT.lock()[..]),
+            idt: &IDT,
+        };
+
+        // This block is safe because by referencing IDT above, we know that we've constructed an
+        // IDT.
+        unsafe {
+            dtables::lidt(&r.ptr)
+        };
+
+        r
+    }
+
     pub fn set_handler(&self, index: usize, entry: IdtEntry) {
         self.idt.lock()[index] = entry;
     }
-}
 
-pub fn idt_ref() -> IdtRef {
-    let r = IdtRef {
-        ptr: DescriptorTablePointer::new_idtp(&IDT.lock()[..]),
-        idt: &IDT,
-    };
-
-    // this block is safe because we've constructed a proper IDT above.
-    unsafe {
-        dtables::lidt(&r.ptr)
-    };
-
-    r
-}
-
-impl IdtRef {
     pub fn enable_interrupts(&self) {
         // This unsafe fn is okay becuase, by virtue of having an IdtRef, we know that we have a
         // valid Idt.
@@ -113,4 +112,3 @@ impl IdtRef {
         }
     }
 }
-

--- a/interrupts/src/lib.rs
+++ b/interrupts/src/lib.rs
@@ -1,7 +1,121 @@
+#![feature(asm)]
+#![feature(naked_functions)]
+#![feature(core_intrinsics)]
 #![no_std]
 
-pub struct IdtRef;
+extern crate x86;
+extern crate pic;
+
+use x86::shared::dtables;
+use x86::shared::dtables::DescriptorTablePointer;
+use x86::bits64::irq::IdtEntry;
+
+use core::intrinsics;
+
+macro_rules! make_idt_entry {
+    ($name:ident, $body:expr) => {{
+        fn body() {
+            $body
+        }
+
+        #[naked]
+        unsafe extern fn $name() {
+            asm!("push rbp
+                  push r15
+                  push r14
+                  push r13
+                  push r12
+                  push r11
+                  push r10
+                  push r9
+                  push r8
+                  push rsi
+                  push rdi
+                  push rdx
+                  push rcx
+                  push rbx
+                  push rax
+                  mov rsi, rsp
+                  push rsi
+                  
+                  call $0
+                  add rsp, 8
+                  pop rax
+                  pop rbx
+                  pop rcx
+                  pop rdx
+                  pop rdi
+                  pop rsi
+                  pop r8
+                  pop r9
+                  pop r10
+                  pop r11
+                  pop r12
+                  pop r13
+                  pop r14
+                  pop r15
+                  pop rbp
+                  iretq" :: "s"(body as fn()) :: "volatile", "intel");
+            intrinsics::unreachable();
+        }
+
+		use x86::shared::paging::VAddr;
+		use x86::shared::PrivilegeLevel;
+
+		let handler = VAddr::from_usize($name as usize);
+
+		// last is "block", idk
+		IdtEntry::new(handler, 0x8, PrivilegeLevel::Ring0, false)
+    }};
+}
+
+static mut IDT: [IdtEntry; 256] = [IdtEntry::MISSING; 256];
+
+pub struct IdtRef {
+    ptr: DescriptorTablePointer<IdtEntry>,
+}
 
 pub fn idt_ref() -> IdtRef {
-    IdtRef
+	// accessing the static mut idt
+	let r = unsafe {
+		IdtRef {
+			ptr: DescriptorTablePointer::new_idtp(&IDT[..]),
+		}
+	};
+
+	let gpf = make_idt_entry!(isr13, {
+		panic!("omg GPF");
+	});
+
+    let timer = make_idt_entry!(isr32, {
+        pic::eoi_for(32);
+
+        unsafe {
+            x86::shared::irq::enable();
+        }
+    });
+
+	// accessing the static mut idt
+	unsafe {
+		IDT[13] = gpf;
+        IDT[32] = timer;
+	}
+
+    // this block is safe because we've constructed a proper IDT above.
+    unsafe {
+        dtables::lidt(&r.ptr)
+    };
+
+    r
 }
+
+impl IdtRef {
+    pub fn enable_interrupts(&self) {
+        // This unsafe fn is okay becuase, by virtue of having an IdtRef, we know that we have a
+        // valid Idt.
+        unsafe {
+            x86::shared::irq::enable();
+        }
+    }
+}
+

--- a/interrupts/src/lib.rs
+++ b/interrupts/src/lib.rs
@@ -38,8 +38,10 @@ macro_rules! make_idt_entry {
                   push rax
                   mov rsi, rsp
                   push rsi
+                  cli
                   
                   call $0
+                  sti
                   add rsp, 8
                   pop rax
                   pop rbx

--- a/interrupts/src/lib.rs
+++ b/interrupts/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(asm)]
 #![feature(naked_functions)]
-#![feature(core_intrinsics)]
 #![no_std]
 
 extern crate x86;
@@ -9,8 +8,6 @@ extern crate pic;
 use x86::shared::dtables;
 use x86::shared::dtables::DescriptorTablePointer;
 use x86::bits64::irq::IdtEntry;
-
-use core::intrinsics;
 
 #[macro_export]
 macro_rules! make_idt_entry {
@@ -38,10 +35,13 @@ macro_rules! make_idt_entry {
                   push rax
                   mov rsi, rsp
                   push rsi
+
                   cli
-                  
+
                   call $0
+
                   sti
+
                   add rsp, 8
                   pop rax
                   pop rbx
@@ -62,13 +62,13 @@ macro_rules! make_idt_entry {
             intrinsics::unreachable();
         }
 
-		use x86::shared::paging::VAddr;
-		use x86::shared::PrivilegeLevel;
+        use x86::shared::paging::VAddr;
+        use x86::shared::PrivilegeLevel;
 
-		let handler = VAddr::from_usize($name as usize);
+        let handler = VAddr::from_usize($name as usize);
 
-		// last is "block", idk
-		IdtEntry::new(handler, 0x8, PrivilegeLevel::Ring0, false)
+        // last is "block", idk
+        IdtEntry::new(handler, 0x8, PrivilegeLevel::Ring0, false)
     }};
 }
 
@@ -88,13 +88,13 @@ impl IdtRef {
 }
 
 pub fn idt_ref() -> IdtRef {
-	// accessing the static mut idt
-	let r = unsafe {
-		IdtRef {
-			ptr: DescriptorTablePointer::new_idtp(&IDT[..]),
+    // accessing the static mut idt
+    let r = unsafe {
+        IdtRef {
+            ptr: DescriptorTablePointer::new_idtp(&IDT[..]),
             idt: &mut IDT,
-		}
-	};
+        }
+    };
 
     // this block is safe because we've constructed a proper IDT above.
     unsafe {

--- a/keyboard/Cargo.toml
+++ b/keyboard/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "keyboard"
+version = "0.1.0"
+authors = ["The intermezzOS team"]
+
+[dependencies]

--- a/keyboard/src/lib.rs
+++ b/keyboard/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_std]
+
+static CODES: [u8; 59] = *b"??1234567890-=??qwertyuiop[]\n?asdfghjkl;'`?\\zxcvbnm,./?*? ?";
+
+pub fn from_scancode(code: usize) -> Option<char> {
+    if code <= 59 { 
+        Some(CODES[code] as char)
+    } else {
+        None
+    }
+}

--- a/pic/Cargo.toml
+++ b/pic/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
-name = "interrupts"
+name = "pic"
 version = "0.1.0"
 authors = ["The intermezzOS team"]
 
 [dependencies]
-x86 = "0.8.0"
-pic = { path = "../pic" }

--- a/pic/src/lib.rs
+++ b/pic/src/lib.rs
@@ -1,0 +1,58 @@
+#![feature(asm)]
+#![no_std]
+
+#[inline]
+pub unsafe fn inb(port: u16) -> u8 {
+    let ret : u8;
+    asm!("inb $1, $0" : "={ax}"(ret) : "{dx}N"(port) : : "volatile");
+    return ret;
+}
+
+#[inline]
+unsafe fn outb(port: u16, val: u8) {
+    asm!("outb $1, $0" : : "{dx}N"(port), "{al}"(val) : : "volatile");
+}
+
+pub fn remap() {
+    unsafe {
+        let pic1_mask = inb(0x21);
+        let pic2_mask = inb(0xA1);
+
+        // initialize both PICs
+        outb(0x20, 0x11);
+        outb(0xA0, 0x11);
+
+        // set vector offset of pic1 to 0x20
+        outb(0x21, 0x20);
+        // set vector offset of pic2 to 0x28
+        outb(0xA1, 0x28);
+
+        // tell PIC1 about PIC2 at IRQ2 (0000 0100)
+        outb(0x21, 4);
+
+        // tell PIC2 its cascade identity (0000 0010)
+        outb(0xA1, 2);
+
+        // set both PICs to 8086 mode
+        outb(0x21, 0x1);
+        outb(0xA1, 0x1);
+
+        // restore masks
+        outb(0x21, pic1_mask);
+        outb(0xA1, pic2_mask);
+    }
+}
+
+pub fn eoi_for(interrupt_number: isize) {
+    unsafe {
+        match interrupt_number {
+            i if i >= 40 => {
+                outb(0xA0, 0x20);
+                outb(0x20, 0x20);
+            },
+            32...40 => outb(0x20, 0x20),
+            _ => {},
+        }
+    }
+}
+

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,5 +1,10 @@
 use core;
+
 use console::Vga;
+
+use interrupts;
+use interrupts::IdtRef;
+
 use spin::Mutex;
 
 #[macro_use]
@@ -7,6 +12,7 @@ mod kprint;
 
 pub struct Context {
     pub vga: Mutex<Vga<&'static mut [u8]>>,
+    pub idt: Mutex<IdtRef>,
 }
 
 impl Context {
@@ -17,6 +23,7 @@ impl Context {
 
         Context {
             vga: Mutex::new(Vga::new(slice)),
+            idt: Mutex::new(interrupts::idt_ref()),
         }
     }
 }

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -2,7 +2,6 @@ use core;
 
 use console::Vga;
 
-use interrupts;
 use interrupts::IdtRef;
 
 use spin::Mutex;
@@ -23,7 +22,7 @@ impl Context {
 
         Context {
             vga: Mutex::new(Vga::new(slice)),
-            idt: interrupts::idt_ref(),
+            idt: IdtRef::new(),
         }
     }
 }

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -12,7 +12,7 @@ mod kprint;
 
 pub struct Context {
     pub vga: Mutex<Vga<&'static mut [u8]>>,
-    pub idt: Mutex<IdtRef>,
+    pub idt: IdtRef,
 }
 
 impl Context {
@@ -23,7 +23,7 @@ impl Context {
 
         Context {
             vga: Mutex::new(Vga::new(slice)),
-            idt: Mutex::new(interrupts::idt_ref()),
+            idt: interrupts::idt_ref(),
         }
     }
 }

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -12,7 +12,7 @@ mod kprint;
 
 pub struct Context {
     pub vga: Mutex<Vga<&'static mut [u8]>>,
-    pub idt: IdtRef,
+    pub idt: Mutex<IdtRef>,
 }
 
 impl Context {
@@ -23,7 +23,7 @@ impl Context {
 
         Context {
             vga: Mutex::new(Vga::new(slice)),
-            idt: interrupts::idt_ref(),
+            idt: Mutex::new(interrupts::idt_ref()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_std]
 
 extern crate console;
+extern crate interrupts;
 extern crate spin;
 
 pub mod kernel;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,9 +39,9 @@ lazy_static! {
 pub extern "C" fn kmain() -> ! {
     pic::remap();
 
-	let gpf = make_idt_entry!(isr13, {
-		panic!("omg GPF");
-	});
+    let gpf = make_idt_entry!(isr13, {
+        panic!("omg GPF");
+    });
 
     let timer = make_idt_entry!(isr32, {
         pic::eoi_for(32);

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,11 +57,11 @@ pub extern "C" fn kmain() -> ! {
         pic::eoi_for(33);
     });
 
-    CONTEXT.idt.lock().set_handler(13, gpf);
-    CONTEXT.idt.lock().set_handler(32, timer);
-    CONTEXT.idt.lock().set_handler(33, keyboard);
+    CONTEXT.idt.set_handler(13, gpf);
+    CONTEXT.idt.set_handler(32, timer);
+    CONTEXT.idt.set_handler(33, keyboard);
 
-    CONTEXT.idt.lock().enable_interrupts();
+    CONTEXT.idt.enable_interrupts();
 
     kprintln!(CONTEXT, "Kernel initialized.");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,14 @@
 #![no_main]
 
 extern crate rlibc;
+extern crate spin;
+
+extern crate console;
+use console::Vga;
+
+extern crate pic;
+
+use spin::Mutex;
 
 #[macro_use]
 extern crate intermezzos;
@@ -11,9 +19,20 @@ extern crate intermezzos;
 #[cfg(not(test))]
 pub mod panic;
 
+static mut PRINT_REF: Option<&'static Mutex<Vga<&'static mut [u8]>>> = None;
+
 #[no_mangle]
 pub extern "C" fn kmain() -> ! {
     let ctx = intermezzos::kernel::Context::new();
+
+    // ... yeah this doesn't quite cut it. SO UNSAFE.
+    unsafe {
+        // so here, we use transmuate to elongate the lifetime to static.
+        PRINT_REF = core::mem::transmute(Some(&ctx.vga));
+    }
+
+    pic::remap();
+    ctx.idt.enable_interrupts();
 
     kprintln!(ctx, "Kernel initialized.");
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -2,8 +2,14 @@ use core::fmt;
 
 #[lang = "panic_fmt"]
 #[no_mangle]
-pub extern fn rust_begin_panic(_msg: fmt::Arguments,
-                               _file: &'static str,
-                               _line: u32) -> ! {
+pub extern fn rust_begin_panic(msg: fmt::Arguments,
+                               file: &'static str,
+                               line: u32) -> ! {
+    unsafe {
+        use core::fmt::Write;
+        let mut vga = ::PRINT_REF.unwrap().lock();
+        vga.write_fmt(format_args!("PANIC: {} {} {}", msg, file, line)).unwrap();
+        vga.flush();
+    }
     loop {}
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,15 +1,11 @@
 use core::fmt;
+use ::CONTEXT;
 
 #[lang = "panic_fmt"]
 #[no_mangle]
 pub extern fn rust_begin_panic(msg: fmt::Arguments,
                                file: &'static str,
                                line: u32) -> ! {
-    unsafe {
-        use core::fmt::Write;
-        let mut vga = ::PRINT_REF.unwrap().lock();
-        vga.write_fmt(format_args!("PANIC: {} {} {}", msg, file, line)).unwrap();
-        vga.flush();
-    }
+    kprintln!(CONTEXT, "PANIC: {} {} {}", msg, file, line);
     loop {}
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -6,6 +6,6 @@ use ::CONTEXT;
 pub extern fn rust_begin_panic(msg: fmt::Arguments,
                                file: &'static str,
                                line: u32) -> ! {
-    kprintln!(CONTEXT, "PANIC: {} {} {}", msg, file, line);
+    kprintln!(CONTEXT, "KERNEL PANIC in {}:{}! Message: {}", file, line, msg);
     loop {}
 }


### PR DESCRIPTION
Re-introduce interrupts.

1. Add a pic crate, we need to remap the pic to enable interrupts.
2. Create the trampoline for creating interrupts
3. Set up the GPF handler. All unused interrupts go here, thanks to the
   x86 crates' MISSING handler.
4. Set up the timer handler. We don't want to do anything with it yet.
5. Set up panic to print something.

Okay, so 5 really, really isn't great. I'm not sure how to get around
it, though. Basically, we have to create a static reference to the thing
we're trying to not keep static. It's gross. Idk.