### PR TITLE
grub-mkrescue can be called grub2-mkrescue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+ifeq ($(shell grub-mkrescue -? &>/dev/null; echo $$?),0)
+    grub-mkrescue = grub-mkrescue
+else
+    ifeq ($(shell grub2-mkrescue -? &>/dev/null; echo $$?),0)
+        grub-mkrescue = grub2-mkrescue
+    else
+      $(error "grub-mkrescue is not found.")
+    endif
+endif
+
 cargo: 
 	xargo build --release --target x86_64-unknown-intermezzos-gnu
 
@@ -9,7 +19,7 @@ iso: cargo grub.cfg
 	mkdir -p target/isofiles/boot/grub
 	cp grub.cfg target/isofiles/boot/grub
 	cp target/x86_64-unknown-intermezzos-gnu/release/intermezzos target/isofiles/boot/
-	grub-mkrescue -o target/os.iso target/isofiles
+	$(grub-mkrescue) -o target/os.iso target/isofiles
 
 run: iso
 	qemu-system-x86_64 -cdrom target/os.iso


### PR DESCRIPTION
The Makefile calls grub-mkrescue util for creation for an image generation.
But this utils is called grub2-mkrescue in Fedora Linux and maybe other
rpm based distros.

This patch updates Makefile, so we will check existence of grub-mkrescue
or grub2-mkrescue before.
