### PR TITLE
boot: set WP and PG bits in one instruction

### DIFF
--- a/src/asm/boot.asm
+++ b/src/asm/boot.asm
@@ -46,8 +46,7 @@ start:
 
     ; enable paging
     mov eax, cr0
-    or eax, 1 << 31
-    or eax, 1 << 16
+    or eax, (1 << 31 | 1 << 16)
     mov cr0, eax
 
     lgdt [gdt64.pointer]


### PR DESCRIPTION
We are setting WP and PG bits with two `or` instruction in boot.asm:

```
mov eax, cr0
or eax, 1 << 31
or eax, 1 << 16
mov cr0, eax
```

The nasm supports `|` operation, so we can do the same in one `or`
instruction.

The result is the same as before:

Before:

```
  5a:	0f 20 c0             	mov    %cr0,%rax
  5d:	0d 00 00 00 80       	or     $0x80000000,%eax
  62:	0d 00 00 01 00       	or     $0x10000,%eax
  67:	0f 22 c0             	mov    %rax,%cr0
```

After we set the same bits but in one instruction:

```
  5a:	0f 20 c0             	mov    %cr0,%rax
  5d:	0d 00 00 01 80       	or     $0x80010000,%eax
  62:	0f 22 c0             	mov    %rax,%cr0
```