### PR TITLE
Install all dependencies on macOS using Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,29 @@ language: rust
 rust:
   - nightly
 
+os:
+  - linux
+  - osx
+
+cache:
+  cargo: true
+  directories:
+    - /usr/local/bin/x86_64-pc-elf-*
+    - /usr/local/bin/grub*
+    # brew directories on OS X
+    - /usr/local/Cellar/x86_64-pc-elf-*
+    - /usr/local/Cellar/grub
+
+before_install:
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update && brew tap homebrew/bundle &&
+      travis_wait 120 brew bundle;
+      printf "\n\n[target.x86_64unknown-intermezzos-gnu]\nlinker = \"/usr/local/bin/x86_64-pc-elf-gcc\"" >> $HOME/.cargo/config;
+    fi
+
 install:
-  - sudo apt-get install grub-common
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install grub-common; fi
   - export PATH="$PATH:$(rustc --print sysroot)/cargo/bin"
   - curl -sf "https://raw.githubusercontent.com/japaric/rust-everywhere/master/install.sh" | bash -s -- --from japaric/xargo
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,16 @@
+# for assembling x86
+brew 'nasm'
+
+# for making a bootable ISO
+brew 'xorriso'
+
+# for running the OS
+brew 'qemu'
+
+# x86_64-pc-elf cross-compile toolchain
+tap 'hawkw/x86_64-pc-elf'
+brew 'x86_64-pc-elf-gcc'
+
+# GRUB
+tap 'hawkw/grub'
+brew 'grub', args: ['with-x86_64-pc-elf', 'HEAD']

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ You'll also need to set this in your `~/.cargo/config`:
 linker = "/usr/local/bin/x86_64-pc-elf-gcc"
 ```
 
-Where `yourusername` is your username.
-
 After all that setup, it’s as easy as:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ Then get this stuff:
 * `grub-mkrescue`: you may also need to install `xorriso`
 * `qemu-system-x86_64`
 
-If you're on OS X, you might want to use [this
-script](http://intermezzos.github.io/book/appendix/osx-install.html) to get
-them. You'll also need to set this in your `~/.cargo/config`:
+If you're on macOS, you can install the dependencies using [Homebrew](http://brew.sh) with the following commands:
+```bash
+$ brew tap homebrew/bundle
+$ brew bundle
+```
+You'll also need to set this in your `~/.cargo/config`:
 
 ```toml
 [target.x86_64-unknown-intermezzos-gnu]
-linker = "/Users/yourusername/opt/bin/x86_64-pc-elf-gcc"
+linker = "/usr/local/bin/x86_64-pc-elf-gcc"
 ```
 
 Where `yourusername` is your username.


### PR DESCRIPTION
Closes #53. 

This PR adds a `Brewfile` which, when used with Homebrew's `brew bundle` command, will install all the tools needed to build intermezzOS. I've also updated the documentation to match.