### PR TITLE
[WIP] implement new VGA as per RFC 0005

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -35,10 +35,10 @@ dependencies = [
  "console 0.1.0",
  "interrupts 0.1.0",
  "keyboard 0.1.0",
- "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pic 0.1.0",
  "rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -47,7 +47,7 @@ name = "interrupts"
 version = "0.1.0"
 dependencies = [
  "pic 0.1.0",
- "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -57,15 +57,15 @@ version = "0.1.0"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -88,8 +88,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -98,7 +98,7 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ dependencies = [
  "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -136,41 +136,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "phf"
-version = "0.7.16"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_shared 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.7.16"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_generator 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_shared 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_generator 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.7.16"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "phf_shared 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.7.16"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -217,8 +217,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf_codegen 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-cpuid 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -227,8 +227,8 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)" = "266c1815d7ca63a5bd86284043faf91e8c95e943e55ce05dc0ae08e952de18bc"
-"checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
-"checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
+"checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
+"checksum libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "9e030dc72013ed68994d1b2cbf36a94dd0e58418ba949c4b0db7eeb70a7a6352"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "88b14378471f7c2adc5262f05b4701ef53e8da376453a8d8fee48e51db745e49"
 "checksum num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c78e054dd19c3fd03419ade63fa661e9c49bb890ce3beb4eee5b7baf93f92f"
@@ -236,15 +236,15 @@ dependencies = [
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
 "checksum num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "54ff603b8334a72fbb27fe66948aac0abaaa40231b3cecd189e76162f6f38aaf"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
-"checksum phf 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)" = "52c875926de24c01b5b69153eaa258b57920a39b44bbce8ef1f2052a6c5a6a1a"
-"checksum phf_codegen 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0a8912c2cc0ea2e8ae70388ec0af9a445e7ab37b3c9cc61f059c2b34db8ed50b"
-"checksum phf_generator 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)" = "04b5ea825e28cb6efd89d9133b129b2003b45a221aeda025509b125b00ecb7c4"
-"checksum phf_shared 0.7.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2c43b5dbe94d31f1f4ed45c50bb06d70e72fd53f15422b0a915b5c237e130dd6"
-"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
+"checksum phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0c6afb2057bb5f846a7b75703f90bc1cef4970c35209f712925db7768e999202"
+"checksum phf_codegen 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "6b63f121bf9a128f2172a65d8313a8e0e79d63874eeb4b4b7d82e6dda6b62f7c"
+"checksum phf_generator 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "50ffbd7970f75afa083c5dd7b6830c97b72b81579c7a92d8134ef2ee6c0c7eb0"
+"checksum phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "286385a0e50d4147bce15b2c19f0cf84c395b0e061aaf840898a7bf664c2cfb7"
+"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum raw-cpuid 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7bc8e963398e6244e1d51c42dd68394f273d39ed8afc9238b74f56041b23dbd3"
 "checksum rlibc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
-"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97b18e9e53de541f11e497357d6c5eaeb39f0cb9c8734e274abe4935f6991fa"
 "checksum serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b5aaee47e038bf9552d30380d3973fff2593ee0a76d81ad4c581f267cdcadf36"
-"checksum spin 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f7035cd2694c317f8ff90efb00feb9e7268febbf6e9b28a8d16da8eb202493"
+"checksum spin 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1d16a26e2b789f86aabddbe91cb82ee2e822beb8a59840d631941b625ef77e53"
 "checksum x86 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "289a79c6ffe63e7948823bc7e6b617856325c752dfec28c4ba50f50a824f55a2"

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -10,35 +10,31 @@ const ROWS: usize = 25;
 const COLS: usize = 80;
 const COL_BYTES: usize = COLS * 2;
 
-pub struct Vga<T: AsMut<[u8]>> {
-    slice: T,
-    buffer: [u8; ROWS * COL_BYTES],
+pub struct Vga<'a> {
+    slice: &'a mut [u8],
     position: usize,
 }
 
-impl Vga<&'static mut [u8]> {
-    pub fn new() -> Vga<&'static mut [u8]> {
+impl Vga<'static> {
+    pub fn new() -> Vga<'static> {
         unsafe {
             Vga::from_raw(core::slice::from_raw_parts_mut(0xb8000 as *mut u8, ROWS * COL_BYTES))
         }
     }
 }
 
-impl<T: AsMut<[u8]>> Vga<T> {
+impl<'a> Vga<'a> {
     // for testing
-    pub unsafe fn from_raw(mut slice: T) -> Vga<T> {
+    pub unsafe fn from_raw(slice: &mut [u8]) -> Vga {
         // we must have enough bytes of backing storage to make this work.
-        assert_eq!(slice.as_mut().len(), ROWS * COL_BYTES);
+        assert_eq!(slice.len(), ROWS * COL_BYTES);
+
+        slice.clone_from_slice(&[0; ROWS * COL_BYTES][..]);
 
         Vga {
             slice: slice,
-            buffer: [0; ROWS * COL_BYTES],
             position: 0,
         }
-    }
-
-    pub fn flush(&mut self) {
-        self.slice.as_mut().clone_from_slice(&self.buffer);
     }
 
     fn write_byte(&mut self, byte: u8) {
@@ -48,13 +44,13 @@ impl<T: AsMut<[u8]>> Vga<T> {
             let current_line = self.position / (COL_BYTES);
             self.position = (current_line + 1) * COL_BYTES;
         } else {
-            self.buffer[i] = byte;
-            self.buffer[i + 1] = color::colorcode(Color::Green, Color::Black);
+            self.slice[i] = byte;
+            self.slice[i + 1] = color::colorcode(Color::Green, Color::Black);
 
             self.position += 2;
         }
 
-        if self.position >= self.buffer.len() {
+        if self.position >= self.slice.len() {
             self.scroll();
         }
     }
@@ -64,19 +60,19 @@ impl<T: AsMut<[u8]>> Vga<T> {
             for cb in 0..COL_BYTES {
                 let prev_position = ((row - 1) * COL_BYTES) + cb;
                 let current_position = (row * COL_BYTES) + cb;
-                self.buffer[prev_position] = self.buffer[current_position];
+                self.slice[prev_position] = self.slice[current_position];
             }
         }
          
         for cb in 0..COL_BYTES/2 {
-            self.buffer[((ROWS - 1) * COL_BYTES) + (cb * 2)] = ' ' as u8;
+            self.slice[((ROWS - 1) * COL_BYTES) + (cb * 2)] = ' ' as u8;
         }
 
         self.position = (ROWS - 1) * COL_BYTES;
     }
 }
 
-impl<T: AsMut<[u8]>> Write for Vga<T> {
+impl<'a> Write for Vga<'a> {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
         for b in s.bytes() {
             self.write_byte(b);
@@ -104,8 +100,8 @@ mod tests {
 
         vga.write_str("a").unwrap();
 
-        assert_eq!(vga.buffer[0], 'a' as u8);
-        assert_eq!(vga.buffer[1], 0x02);
+        assert_eq!(vga.slice[0], 'a' as u8);
+        assert_eq!(vga.slice[1], 0x02);
     }
 
     #[test]
@@ -119,14 +115,14 @@ mod tests {
         let word = "word";
         vga.write_str(word).unwrap();
 
-        assert_eq!(vga.buffer[0], 'w' as u8);
-        assert_eq!(vga.buffer[1], 0x02);
-        assert_eq!(vga.buffer[2], 'o' as u8);
-        assert_eq!(vga.buffer[3], 0x02);
-        assert_eq!(vga.buffer[4], 'r' as u8);
-        assert_eq!(vga.buffer[5], 0x02);
-        assert_eq!(vga.buffer[6], 'd' as u8);
-        assert_eq!(vga.buffer[7], 0x02);
+        assert_eq!(vga.slice[0], 'w' as u8);
+        assert_eq!(vga.slice[1], 0x02);
+        assert_eq!(vga.slice[2], 'o' as u8);
+        assert_eq!(vga.slice[3], 0x02);
+        assert_eq!(vga.slice[4], 'r' as u8);
+        assert_eq!(vga.slice[5], 0x02);
+        assert_eq!(vga.slice[6], 'd' as u8);
+        assert_eq!(vga.slice[7], 0x02);
     }
 
     #[test]
@@ -139,28 +135,28 @@ mod tests {
         vga.write_str("hello ").unwrap();
         vga.write_str("world").unwrap();
 
-        assert_eq!(vga.buffer[0], 'h' as u8);
-        assert_eq!(vga.buffer[1], 0x02);
-        assert_eq!(vga.buffer[2], 'e' as u8);
-        assert_eq!(vga.buffer[3], 0x02);
-        assert_eq!(vga.buffer[4], 'l' as u8);
-        assert_eq!(vga.buffer[5], 0x02);
-        assert_eq!(vga.buffer[6], 'l' as u8);
-        assert_eq!(vga.buffer[7], 0x02);
-        assert_eq!(vga.buffer[8], 'o' as u8);
-        assert_eq!(vga.buffer[9], 0x02);
-        assert_eq!(vga.buffer[10], ' ' as u8);
-        assert_eq!(vga.buffer[11], 0x02);
-        assert_eq!(vga.buffer[12], 'w' as u8);
-        assert_eq!(vga.buffer[13], 0x02);
-        assert_eq!(vga.buffer[14], 'o' as u8);
-        assert_eq!(vga.buffer[15], 0x02);
-        assert_eq!(vga.buffer[16], 'r' as u8);
-        assert_eq!(vga.buffer[17], 0x02);
-        assert_eq!(vga.buffer[18], 'l' as u8);
-        assert_eq!(vga.buffer[19], 0x02);
-        assert_eq!(vga.buffer[20], 'd' as u8);
-        assert_eq!(vga.buffer[21], 0x02);
+        assert_eq!(vga.slice[0], 'h' as u8);
+        assert_eq!(vga.slice[1], 0x02);
+        assert_eq!(vga.slice[2], 'e' as u8);
+        assert_eq!(vga.slice[3], 0x02);
+        assert_eq!(vga.slice[4], 'l' as u8);
+        assert_eq!(vga.slice[5], 0x02);
+        assert_eq!(vga.slice[6], 'l' as u8);
+        assert_eq!(vga.slice[7], 0x02);
+        assert_eq!(vga.slice[8], 'o' as u8);
+        assert_eq!(vga.slice[9], 0x02);
+        assert_eq!(vga.slice[10], ' ' as u8);
+        assert_eq!(vga.slice[11], 0x02);
+        assert_eq!(vga.slice[12], 'w' as u8);
+        assert_eq!(vga.slice[13], 0x02);
+        assert_eq!(vga.slice[14], 'o' as u8);
+        assert_eq!(vga.slice[15], 0x02);
+        assert_eq!(vga.slice[16], 'r' as u8);
+        assert_eq!(vga.slice[17], 0x02);
+        assert_eq!(vga.slice[18], 'l' as u8);
+        assert_eq!(vga.slice[19], 0x02);
+        assert_eq!(vga.slice[20], 'd' as u8);
+        assert_eq!(vga.slice[21], 0x02);
     }
 
     #[test]
@@ -172,28 +168,28 @@ mod tests {
 
         vga.write_str("hello\nworld\n!").unwrap();
 
-        assert_eq!(vga.buffer[0], 'h' as u8);
-        assert_eq!(vga.buffer[1], 0x02);
-        assert_eq!(vga.buffer[2], 'e' as u8);
-        assert_eq!(vga.buffer[3], 0x02);
-        assert_eq!(vga.buffer[4], 'l' as u8);
-        assert_eq!(vga.buffer[5], 0x02);
-        assert_eq!(vga.buffer[6], 'l' as u8);
-        assert_eq!(vga.buffer[7], 0x02);
-        assert_eq!(vga.buffer[8], 'o' as u8);
-        assert_eq!(vga.buffer[9], 0x02);
-        assert_eq!(vga.buffer[160], 'w' as u8);
-        assert_eq!(vga.buffer[161], 0x02);
-        assert_eq!(vga.buffer[162], 'o' as u8);
-        assert_eq!(vga.buffer[163], 0x02);
-        assert_eq!(vga.buffer[164], 'r' as u8);
-        assert_eq!(vga.buffer[165], 0x02);
-        assert_eq!(vga.buffer[166], 'l' as u8);
-        assert_eq!(vga.buffer[167], 0x02);
-        assert_eq!(vga.buffer[168], 'd' as u8);
-        assert_eq!(vga.buffer[169], 0x02);
-        assert_eq!(vga.buffer[320], '!' as u8);
-        assert_eq!(vga.buffer[321], 0x02);
+        assert_eq!(vga.slice[0], 'h' as u8);
+        assert_eq!(vga.slice[1], 0x02);
+        assert_eq!(vga.slice[2], 'e' as u8);
+        assert_eq!(vga.slice[3], 0x02);
+        assert_eq!(vga.slice[4], 'l' as u8);
+        assert_eq!(vga.slice[5], 0x02);
+        assert_eq!(vga.slice[6], 'l' as u8);
+        assert_eq!(vga.slice[7], 0x02);
+        assert_eq!(vga.slice[8], 'o' as u8);
+        assert_eq!(vga.slice[9], 0x02);
+        assert_eq!(vga.slice[160], 'w' as u8);
+        assert_eq!(vga.slice[161], 0x02);
+        assert_eq!(vga.slice[162], 'o' as u8);
+        assert_eq!(vga.slice[163], 0x02);
+        assert_eq!(vga.slice[164], 'r' as u8);
+        assert_eq!(vga.slice[165], 0x02);
+        assert_eq!(vga.slice[166], 'l' as u8);
+        assert_eq!(vga.slice[167], 0x02);
+        assert_eq!(vga.slice[168], 'd' as u8);
+        assert_eq!(vga.slice[169], 0x02);
+        assert_eq!(vga.slice[320], '!' as u8);
+        assert_eq!(vga.slice[321], 0x02);
     }
 
     #[test]
@@ -208,9 +204,9 @@ mod tests {
             vga.write_byte('\n' as u8);
         }
 
-        assert_eq!(vga.buffer[0], 'c' as u8);
+        assert_eq!(vga.slice[0], 'c' as u8);
         for cb in 0..COL_BYTES/2 {
-            assert_eq!(vga.buffer[(ROWS - 1) * COL_BYTES + (cb * 2)], ' ' as u8);
+            assert_eq!(vga.slice[(ROWS - 1) * COL_BYTES + (cb * 2)], ' ' as u8);
         }
     }
 

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -16,8 +16,17 @@ pub struct Vga<T: AsMut<[u8]>> {
     position: usize,
 }
 
+impl Vga<&'static mut [u8]> {
+    pub fn new() -> Vga<&'static mut [u8]> {
+        unsafe {
+            Vga::from_raw(core::slice::from_raw_parts_mut(0xb8000 as *mut u8, ROWS * COL_BYTES))
+        }
+    }
+}
+
 impl<T: AsMut<[u8]>> Vga<T> {
-    pub fn new(mut slice: T) -> Vga<T> {
+    // for testing
+    pub unsafe fn from_raw(mut slice: T) -> Vga<T> {
         // we must have enough bytes of backing storage to make this work.
         assert_eq!(slice.as_mut().len(), ROWS * COL_BYTES);
 
@@ -89,7 +98,9 @@ mod tests {
     fn write_a_letter() {
         let mut mock_memory = [0u8; ROWS * COL_BYTES];
 
-        let mut vga = Vga::new(&mut mock_memory[..]);
+        let mut vga = unsafe {
+            Vga::from_raw(&mut mock_memory[..])
+        };
 
         vga.write_str("a").unwrap();
 
@@ -100,7 +111,10 @@ mod tests {
     #[test]
     fn write_a_word() {
         let mut mock_memory = [0u8; ROWS * COL_BYTES];
-        let mut vga = Vga::new(&mut mock_memory[..]);
+
+        let mut vga = unsafe {
+            Vga::from_raw(&mut mock_memory[..])
+        };
 
         let word = "word";
         vga.write_str(word).unwrap();
@@ -118,7 +132,9 @@ mod tests {
     #[test]
     fn write_multiple_words() {
         let mut mock_memory = [0u8; ROWS * COL_BYTES];
-        let mut vga = Vga::new(&mut mock_memory[..]);
+        let mut vga = unsafe {
+            Vga::from_raw(&mut mock_memory[..])
+        };
 
         vga.write_str("hello ").unwrap();
         vga.write_str("world").unwrap();
@@ -150,7 +166,9 @@ mod tests {
     #[test]
     fn write_newline() {
         let mut mock_memory = [0u8; ROWS * COL_BYTES];
-        let mut vga = Vga::new(&mut mock_memory[..]);
+        let mut vga = unsafe {
+            Vga::from_raw(&mut mock_memory[..])
+        };
 
         vga.write_str("hello\nworld\n!").unwrap();
 
@@ -181,7 +199,9 @@ mod tests {
     #[test]
     fn write_scroll() {
         let mut mock_memory = [0u8; ROWS * COL_BYTES];
-        let mut vga = Vga::new(&mut mock_memory[..]);
+        let mut vga = unsafe {
+            Vga::from_raw(&mut mock_memory[..])
+        };
 
         for b in "abcdefghijklmnopqrstuvwxyz".bytes() {
             vga.write_byte(b);

--- a/console/tests/vga.rs
+++ b/console/tests/vga.rs
@@ -24,29 +24,3 @@ fn write() {
     };
     check_write(vga);
 }
-
-#[test]
-fn flush() {
-    let mut mock_memory = vec![0u8; 25 * 80 * 2];
-
-    {
-        let mut vga = unsafe {
-            Vga::from_raw(&mut mock_memory)
-        };
-
-        vga.write_str("hello").unwrap();
-
-        vga.flush();
-    }
-
-    assert_eq!(mock_memory[0], 'h' as u8);
-    assert_eq!(mock_memory[1], 0x02);
-    assert_eq!(mock_memory[2], 'e' as u8);
-    assert_eq!(mock_memory[3], 0x02);
-    assert_eq!(mock_memory[4], 'l' as u8);
-    assert_eq!(mock_memory[5], 0x02);
-    assert_eq!(mock_memory[6], 'l' as u8);
-    assert_eq!(mock_memory[7], 0x02);
-    assert_eq!(mock_memory[8], 'o' as u8);
-    assert_eq!(mock_memory[9], 0x02);
-}

--- a/console/tests/vga.rs
+++ b/console/tests/vga.rs
@@ -8,7 +8,9 @@ use console::Vga;
 fn create() {
     let mut mock_memory = vec![0u8; 25 * 80 * 2];
 
-    Vga::new(&mut mock_memory);
+    unsafe {
+        Vga::from_raw(&mut mock_memory)
+    };
 }
 
 fn check_write<T: Write>(_: T) { }
@@ -16,7 +18,10 @@ fn check_write<T: Write>(_: T) { }
 #[test]
 fn write() {
     let mut mock_memory = vec![0u8; 25 * 80 * 2];
-    let vga = Vga::new(&mut mock_memory);
+
+    let vga = unsafe {
+        Vga::from_raw(&mut mock_memory)
+    };
     check_write(vga);
 }
 
@@ -25,7 +30,9 @@ fn flush() {
     let mut mock_memory = vec![0u8; 25 * 80 * 2];
 
     {
-        let mut vga = Vga::new(&mut mock_memory);
+        let mut vga = unsafe {
+            Vga::from_raw(&mut mock_memory)
+        };
 
         vga.write_str("hello").unwrap();
 

--- a/src/kernel/kprint.rs
+++ b/src/kernel/kprint.rs
@@ -24,6 +24,5 @@ macro_rules! kprint {
         use core::fmt::Write;
         let mut vga = $ctx.vga.lock();
         vga.write_fmt(format_args!($($arg)*)).unwrap();
-        vga.flush();
     });
 }

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,5 +1,3 @@
-use core;
-
 use console::Vga;
 
 use interrupts::IdtRef;
@@ -16,12 +14,8 @@ pub struct Context {
 
 impl Context {
     pub fn new() -> Context {
-        let slice = unsafe {
-            core::slice::from_raw_parts_mut(0xb8000 as *mut u8, 4000)
-        };
-
         Context {
-            vga: Mutex::new(Vga::new(slice)),
+            vga: Mutex::new(Vga::new()),
             idt: IdtRef::new(),
         }
     }

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -8,7 +8,7 @@ use spin::Mutex;
 mod kprint;
 
 pub struct Context {
-    pub vga: Mutex<Vga<&'static mut [u8]>>,
+    pub vga: Mutex<Vga<'static>>,
     pub idt: IdtRef,
 }
 


### PR DESCRIPTION
- re-implement `Vga::new` to hide pointer location from the kernel

  since the pointer location 0xb8000 is already known by the VGA
  it should be inside the VGA's implementation and not the kernel's

- implement `Vga::from_raw`