### PR TITLE
Update x86_64-unknown-intermezzos-gnu.json to work with recent changes

### DIFF
--- a/x86_64-unknown-intermezzos-gnu.json
+++ b/x86_64-unknown-intermezzos-gnu.json
@@ -3,6 +3,7 @@
 	"cpu": "x86-64",
 	"data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
 	"executables": true,
+        "linker-flavor": "gcc",
 	"llvm-target": "x86_64-unknown-none-gnu",
 	"no-compiler-rt": true,
 	"os": "intermezzos",

--- a/x86_64-unknown-intermezzos-gnu.json
+++ b/x86_64-unknown-intermezzos-gnu.json
@@ -10,7 +10,9 @@
 	"target-endian": "little",
 	"target-pointer-width": "64",
 	"features": "-mmx,-fxsr,-sse,-sse2,+soft-float",
-	"pre-link-args": ["-Tlayout.ld", "-Wl,-n", "-nostartfiles"],
+	"pre-link-args": {
+		"gcc": ["-Tlayout.ld", "-Wl,-n", "-nostartfiles"]
+	},
 	"disable-redzone": true,
 	"eliminate-frame-pointer": false
 }


### PR DESCRIPTION
Rust PR rust-lang/rust#40018 added the `"linker-flavor"` field to target.json files. This field is required; Cargo will refuse to build without it (with a rather cryptic error message).

The addition of the `"linker-flavor"` field also changed how pre-link args are specified in target.json files. Cargo silently ignores the old syntax, resulting in linker args not being passed. 

This PR updates IntermezzOS'  `x86_64-unknown-intermezzos-gnu.json` target file to be compatible with these changes. it should fix the build with recent Cargo versions.

Fixes #111 