### PR TITLE
target: specify explicit linker and long flags

### DIFF
--- a/x86_64-unknown-intermezzos-gnu.json
+++ b/x86_64-unknown-intermezzos-gnu.json
@@ -3,7 +3,8 @@
 	"cpu": "x86-64",
 	"data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
 	"executables": true,
-        "linker-flavor": "gcc",
+	"linker": "gcc",
+	"linker-flavor": "gcc",
 	"llvm-target": "x86_64-unknown-none-gnu",
 	"no-compiler-rt": true,
 	"os": "intermezzos",
@@ -11,7 +12,11 @@
 	"target-pointer-width": "64",
 	"features": "-mmx,-fxsr,-sse,-sse2,+soft-float",
 	"pre-link-args": {
-		"gcc": ["-Tlayout.ld", "-Wl,-n", "-nostartfiles"]
+		"gcc": [
+			"-Wl,--script=layout.ld",
+			"-Wl,--nmagic",
+			"-nostartfiles"
+		]
 	},
 	"disable-redzone": true,
 	"eliminate-frame-pointer": false


### PR DESCRIPTION
* By specifying the linker as "gcc", it's ensured that no other linker is
  used and the specified linker-flavor is compatible with the executed
  linker.
  I wasn't able to find out how the linker is looked up in the default
  case, but in a development shell I use, it ended up being clang.
* Pass "--script" as linker-flag
* Use long options to allow for more intuitive reading

--- 

Fixes #111 for me