### PR TITLE
Update to latest version of bootimage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -76,4 +76,4 @@ before_test:
 # environment variable.
 test_script:
   - cargo test
-  - bootimage build --target intermezzos
+  - bootimage build --target intermezzos.json

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,6 @@ cache:
   - '%USERPROFILE%\.cargo\config'
   - '%USERPROFILE%\.cargo\env'
   - '%USERPROFILE%\.cargo\.crates.toml'
-  - '%USERPROFILE%\.xargo'
   - target
 
 ## Install Script ##
@@ -67,7 +66,7 @@ before_test:
   - rustup component add rust-src
   - set RUST_BACKTRACE=1
   - if not exist %USERPROFILE%\.cargo\bin\cargo-install-update.exe cargo install cargo-update
-  - if not exist %USERPROFILE%\.cargo\bin\xargo.exe cargo install xargo
+  - if not exist %USERPROFILE%\.cargo\bin\cargo-xbuild.exe cargo install cargo-xbuild
   - if not exist %USERPROFILE%\.cargo\bin\bootimage.exe cargo install bootimage
   - cargo install-update -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ language: rust
 rust:
   - nightly
 
-    
+
 os:
   - linux
   - osx
 
 before_script:
-  - rustup component add rustfmt-preview      
+  - rustup component add rustfmt-preview
   - rustup component add rust-src
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/xargo || cargo install xargo)
+  - (test -x $HOME/.cargo/bin/cargo-xbuild || cargo install cargo-xbuild)
   - (test -x $HOME/.cargo/bin/bootimage || cargo install bootimage)
   - cargo install-update -a
 
@@ -21,8 +21,4 @@ script:
   - bootimage build --target intermezzos.json
   - cargo fmt -- --write-mode=diff
 
-cache:
-  directories:
-    - $HOME/.cargo
-    - $HOME/.xargo
-    - $TRAVIS_BUILD_DIR/target
+cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 
 script:
   - cargo test
-  - bootimage build --target intermezzos
+  - bootimage build --target intermezzos.json
   - cargo fmt -- --write-mode=diff
 
 cache:


### PR DESCRIPTION
Bootimage 0.3.0 was released with two breaking changes:

- [cargo-xbuild](https://github.com/rust-osdev/cargo-xbuild) is used instead of xargo
- bootimage now expects a path for --target (including the `.json` extension)

This should fix the CI build.